### PR TITLE
fix: 修改 winlog-mcp FastMCP 初始化代码

### DIFF
--- a/external_mcp/winlog-mcp/src/main.py
+++ b/external_mcp/winlog-mcp/src/main.py
@@ -21,9 +21,7 @@ class Settings:
     SIZE = 10
 
 
-mcp = FastMCP(
-    describe="Pywin32 win32evtlog for Retrieval Windows Logs"
-)
+mcp = FastMCP("Pywin32 win32evtlog for Retrieval Windows Logs")
 
 
 @mcp.tool()


### PR DESCRIPTION
# Pull Request

- fix(winlog-mcp): 修复迁移后 Cline 无法连接 MCP Server 的问题

## 📝 更改说明

在将 `winlog-mcp` 从旧目录迁移到 `external_mcp/winlog-mcp/` 后，尽管更新了 Cline 的配置文件路径，但 Cline 仍然无法连接到 MCP Server，并报告 `MCP error -32000: Connection closed` 错误。

经排查，此问题与 `FastMCP` 类的实例化方式有关。旧的写法 `FastMCP(describe=...)` 在新环境下导致了连接失败。

## 🎯 关联Issue

关闭 #1 

## 📋 更改内容

本次修复将 `winlog-mcp` 中 `FastMCP` 的实例化方式从关键字参数：

```python
mcp = FastMCP(
    describe="Pywin32 win32evtlog for Retrieval Windows Logs"
)

修改为位置参数：
```python
mcp = FastMCP("Pywin32 win32evtlog for Retrieval Windows Logs")
```

此外，为了确保 win32evtlog 能够正常工作，需要以管理员权限启动服务（**以管理员身份运行 VS Code 或终端**）。

## 🧪 测试情况

本地测试已通过。
<img width="785" height="84" alt="image" src="https://github.com/user-attachments/assets/4d97296c-e24e-4cf5-a287-3ebc38d7b403" />


