### PR TITLE
feat(ioc): 添加 Selenium 实现的微步在线查询工具v1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,13 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "opencv-python>=4.12.0.88", 
+    "opencv-python>=4.12.0.88",
     "pillow>=11.3.0",
     "pyautogui>=0.9.54",
     "pydantic>=2.11.7",
     "pywin32>=311; sys_platform == 'win32'",
     "mcp>=1.0.0",
+    "selenium>=4.35.0",
 ]
 
 [project.optional-dependencies]

--- a/src/mcpsectrace/mcp_servers/ioc_mcp.py
+++ b/src/mcpsectrace/mcp_servers/ioc_mcp.py
@@ -1,0 +1,190 @@
+import os
+import time
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from mcp.server.fastmcp import FastMCP
+
+# ==============================================================================
+# ---                           CONFIGURATION                            ---
+# ==============================================================================
+# 请在此处修改所有路径和设置
+
+# Chrome 和 ChromeDriver 的可执行文件路径
+CHROME_EXE_PATH = r"D:\OneDrive\NDSS\Selenium_gpt\chrome-win64\chrome.exe"
+CHROMEDRIVER_EXE_PATH = r"D:\OneDrive\NDSS\Selenium_gpt\chromedriver-win64\chromedriver.exe"
+
+# 持久化的用户数据目录路径
+# 指定一个Chrome用户配置文件夹，脚本将加载并使用其中的Cookies、会话等信息。
+# 如果想从一个全新的状态开始，可以指向一个空文件夹。
+USER_DATA_DIR = r"C:\Users\Sssu\AppData\Local\Google\Chrome for Testing\User Data"
+
+#页面加载等待时间（秒）
+PAGE_LOAD_WAIT_SECONDS = 10
+
+# 结果输出目录，将结果保存在指定的子文件夹中
+OUTPUT_DIR = "src/mcpsectrace/mcp_servers/logs/ioc"
+
+# ==============================================================================
+
+mcp = FastMCP("ioc", log_level="ERROR",port = 8888)
+
+@mcp.tool()
+def query_threatbook_ip_and_save(ip_address: str) -> str:
+    """
+    使用 Selenium 打开微步在线（ThreatBook）查询指定 IP，并保存完整的 HTML 页面。
+    此版本会使用持久化的用户数据目录来保留会话信息（如 Cookies）。
+
+    Args:
+        ip_address (str): 需要查询的 IP 地址。
+
+    """
+    # 检查路径是否存在
+    if not os.path.exists(CHROME_EXE_PATH):
+        return f"错误：Chrome 浏览器路径不存在 -> {CHROME_EXE_PATH}"
+    if not os.path.exists(CHROMEDRIVER_EXE_PATH):
+        return f"错误：ChromeDriver 路径不存在 -> {CHROMEDRIVER_EXE_PATH}"
+
+    # 配置 Chrome 选项
+    chrome_options = Options()
+    chrome_options.binary_location = CHROME_EXE_PATH
+    
+    # 使用配置区的用户数据目录路径
+    user_data_dir_abs = os.path.abspath(USER_DATA_DIR)
+    print(f"使用持久化用户数据目录: {user_data_dir_abs}")
+    chrome_options.add_argument(f"--user-data-dir={user_data_dir_abs}")
+    
+    # 其他浏览器选项
+    # chrome_options.add_argument("--headless")  # 如果需要后台运行，请取消此行注释
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--window-size=1920x1080")
+
+    # 配置 ChromeDriver 服务
+    service = Service(executable_path=CHROMEDRIVER_EXE_PATH)
+
+    driver = None
+    try:
+        # 初始化 WebDriver
+        driver = webdriver.Chrome(service=service, options=chrome_options)
+        
+        url = f"https://x.threatbook.com/v5/ip/{ip_address}"
+        print(f"正在访问: {url}")
+        driver.get(url)
+        
+        # 使用配置区的等待时间
+        print(f"页面加载中，请等待 {PAGE_LOAD_WAIT_SECONDS} 秒...")
+        time.sleep(PAGE_LOAD_WAIT_SECONDS)
+        
+        page_content = driver.page_source
+        # 定义输出文件名
+        output_filename = f"{ip_address}.html"
+        
+        # 获取输出目录的绝对路径
+        output_dir_abs = os.path.abspath(OUTPUT_DIR)
+
+        # 确保输出目录存在，如果不存在则递归创建
+        os.makedirs(output_dir_abs, exist_ok=True)
+        # 使用 os.path.join 来构建跨平台兼容的完整文件路径
+        output_filepath = os.path.join(output_dir_abs, output_filename)
+
+        with open(output_filepath, 'w', encoding='utf-8') as f:
+            f.write(page_content)
+            
+        print(f"页面已成功保存到: {output_filepath}")
+        return output_filepath
+
+    except Exception as e:
+        error_message = f"在查询 IP {ip_address} 时发生错误: {e}"
+        print(error_message)
+        return error_message
+        
+    finally:
+        # 确保浏览器被关闭
+        if driver:
+            driver.quit()
+
+@mcp.tool()
+def query_threatbook_domain_and_save(domain_name: str) -> str:
+    """
+    使用 Selenium 打开微步在线（ThreatBook）查询指定域名，并保存完整的 HTML 页面。
+    Args:
+        domain_name (str): 需要查询的域名。
+    """
+    # 检查路径是否存在
+    if not os.path.exists(CHROME_EXE_PATH):
+        return f"错误：Chrome 浏览器路径不存在 -> {CHROME_EXE_PATH}"
+    if not os.path.exists(CHROMEDRIVER_EXE_PATH):
+        return f"错误：ChromeDriver 路径不存在 -> {CHROMEDRIVER_EXE_PATH}"
+
+    # 配置 Chrome 选项
+    chrome_options = Options()
+    chrome_options.binary_location = CHROME_EXE_PATH
+    user_data_dir_abs = os.path.abspath(USER_DATA_DIR)
+    print(f"使用持久化用户数据目录: {user_data_dir_abs}")
+    chrome_options.add_argument(f"--user-data-dir={user_data_dir_abs}")
+    # chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--window-size=1920x1080")
+
+    # 配置 ChromeDriver 服务
+    service = Service(executable_path=CHROMEDRIVER_EXE_PATH)
+    driver = None
+    try:
+        driver = webdriver.Chrome(service=service, options=chrome_options)
+        
+        # 【修改】URL 变更为 domain 查询
+        url = f"https://x.threatbook.com/v5/domain/{domain_name}"
+        print(f"正在访问: {url}")
+        driver.get(url)
+        
+        print(f"页面加载中，请等待 {PAGE_LOAD_WAIT_SECONDS} 秒...")
+        time.sleep(PAGE_LOAD_WAIT_SECONDS)
+        
+        page_content = driver.page_source
+        
+        # 【修改】文件名以 domain 命名
+        output_filename = f"{domain_name}.html"
+        output_dir_abs = os.path.abspath(OUTPUT_DIR)
+        os.makedirs(output_dir_abs, exist_ok=True)
+        output_filepath = os.path.join(output_dir_abs, output_filename)
+
+        with open(output_filepath, 'w', encoding='utf-8') as f:
+            f.write(page_content)
+            
+        print(f"页面已成功保存到: {output_filepath}")
+        return output_filepath
+
+    except Exception as e:
+        # 【修改】错误信息变更为 domain
+        error_message = f"在查询域名 {domain_name} 时发生错误: {e}"
+        print(error_message)
+        return error_message
+        
+    finally:
+        if driver:
+            driver.quit()
+
+
+
+# --- 主程序入口，用于直接运行测试 ---
+if __name__ == '__main__':
+
+#     print("--- 开始测试 IP 查询 ---")
+#     ip_to_query = "1.1.1.1"
+#     ip_result_path = query_threatbook_ip_and_save(ip_to_query)
+    
+#     if ip_result_path and ip_result_path.endswith(".html"):
+#         print(f"\nIP 查询任务完成！文件已保存在: {ip_result_path}\n")
+#     else:
+#         print(f"\nIP 查询任务失败: {ip_result_path}\n")
+
+    print("--- 开始测试域名查询 ---")
+    domain_to_query = "db.testyk.com"  
+    domain_result_path = query_threatbook_domain_and_save(domain_to_query)
+
+    if domain_result_path and domain_result_path.endswith(".html"):
+        print(f"\n域名查询任务完成！文件已保存在: {domain_result_path}")
+    else:
+        print(f"\n域名查询任务失败: {domain_result_path}")

--- a/uv.lock
+++ b/uv.lock
@@ -63,6 +63,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -270,6 +283,7 @@ dependencies = [
     { name = "pyautogui" },
     { name = "pydantic" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "selenium" },
 ]
 
 [package.optional-dependencies]
@@ -295,6 +309,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=311" },
+    { name = "selenium", specifier = ">=4.35.0" },
 ]
 provides-extras = ["dev"]
 
@@ -387,6 +402,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1f/795e7f4aa2eacc59afa4fb61a2e35e510d06414dd5a802b51a012d691b37/opencv_python-4.12.0.88-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:092c16da4c5a163a818f120c22c5e4a2f96e0db4f24e659c701f1fe629a690f9", size = 67041680, upload-time = "2025-07-07T09:14:01.995Z" },
     { url = "https://files.pythonhosted.org/packages/02/96/213fea371d3cb2f1d537612a105792aa0a6659fb2665b22cad709a75bd94/opencv_python-4.12.0.88-cp37-abi3-win32.whl", hash = "sha256:ff554d3f725b39878ac6a2e1fa232ec509c36130927afc18a1719ebf4fbf4357", size = 30284131, upload-time = "2025-07-07T09:14:08.819Z" },
     { url = "https://files.pythonhosted.org/packages/fa/80/eb88edc2e2b11cd2dd2e56f1c80b5784d11d6e6b7f04a1145df64df40065/opencv_python-4.12.0.88-cp37-abi3-win_amd64.whl", hash = "sha256:d98edb20aa932fd8ebd276a72627dad9dc097695b3d435a4257557bbb49a79d2", size = 39000307, upload-time = "2025-07-07T09:14:16.641Z" },
+]
+
+[[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
 ]
 
 [[package]]
@@ -495,6 +522,15 @@ dependencies = [
     { name = "pytweening" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/ff/cdae0a8c2118a0de74b6cf4cbcdcaf8fd25857e6c3f205ce4b1794b27814/PyAutoGUI-0.9.54.tar.gz", hash = "sha256:dd1d29e8fd118941cb193f74df57e5c6ff8e9253b99c7b04f39cfc69f3ae04b2", size = 61236, upload-time = "2023-05-24T20:11:32.972Z" }
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
+]
 
 [[package]]
 name = "pydantic"
@@ -637,6 +673,15 @@ name = "pyscreeze"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/f0/cb456ac4f1a73723d5b866933b7986f02bacea27516629c00f8e7da94c2d/pyscreeze-1.0.1.tar.gz", hash = "sha256:cf1662710f1b46aa5ff229ee23f367da9e20af4a78e6e365bee973cad0ead4be", size = 27826, upload-time = "2024-08-20T23:03:07.291Z" }
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
 
 [[package]]
 name = "pytest"
@@ -800,12 +845,38 @@ wheels = [
 ]
 
 [[package]]
+name = "selenium"
+version = "4.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "trio" },
+    { name = "trio-websocket" },
+    { name = "typing-extensions" },
+    { name = "urllib3", extra = ["socks"] },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/67/9016942b5781843cfea6f5bc1383cea852d9fa08f85f55a0547874525b5c/selenium-4.35.0.tar.gz", hash = "sha256:83937a538afb40ef01e384c1405c0863fa184c26c759d34a1ebbe7b925d3481c", size = 907991, upload-time = "2025-08-12T15:46:40.822Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/ef/d0e033e1b3f19a0325ce03863b68d709780908381135fc0f9436dea76a7b/selenium-4.35.0-py3-none-any.whl", hash = "sha256:90bb6c6091fa55805785cf1660fa1e2176220475ccdb466190f654ef8eef6114", size = 9602106, upload-time = "2025-08-12T15:46:38.244Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -833,6 +904,37 @@ wheels = [
 ]
 
 [[package]]
+name = "trio"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/c1/68d582b4d3a1c1f8118e18042464bb12a7c1b75d64d75111b297687041e3/trio-0.30.0.tar.gz", hash = "sha256:0781c857c0c81f8f51e0089929a26b5bb63d57f927728a5586f7e36171f064df", size = 593776, upload-time = "2025-04-21T00:48:19.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/8e/3f6dfda475ecd940e786defe6df6c500734e686c9cd0a0f8ef6821e9b2f2/trio-0.30.0-py3-none-any.whl", hash = "sha256:3bf4f06b8decf8d3cf00af85f40a89824669e2d033bb32469d34840edcfc22a5", size = 499194, upload-time = "2025-04-21T00:48:17.167Z" },
+]
+
+[[package]]
+name = "trio-websocket"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "outcome" },
+    { name = "trio" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221, upload-time = "2025-02-25T05:16:57.545Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -854,6 +956,20 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.35.0"
 source = { registry = "https://pypi.org/simple" }
@@ -864,4 +980,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/4a/44d3c295350d776427904d73c189e10aeae66d7f555bb2feee16d1e4ba5a/wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065", size = 53425, upload-time = "2022-08-23T19:58:21.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736", size = 24226, upload-time = "2022-08-23T19:58:19.96Z" },
 ]


### PR DESCRIPTION
# Pull Request

## 📝 更改说明

利用 Selenium 对接微步在线（ThreatBook）的功能。通过模拟浏览器操作，新增了两个核心工具函数：query_threatbook_ip_and_save 和 query_threatbook_domain_and_save。这两个函数分别用于查询指定的 IP 地址和域名，并将返回的完整情报页面保存为 HTML 文件。

目前需要提前在浏览器登录一次，然后再利用持久化用户会话（通过 USER_DATA_DIR 配置），可以有效绕过登录验证码，确保查询的稳定性。需要注意的是，目前只是把整个界面保存下来，后续还需要对保存的 HTML 内容进行解析，提取关键信息。

## 🎯 关联Issue
#2 

## 📋 更改内容
- [x] 新增功能
- [ ] Bug修复  
- [ ] 文档更新
- [ ] 代码重构
- [ ] 测试改进
