### PR TITLE
build(deps): 添加 numpy 依赖并调整 opencv-python 顺序

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,14 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "opencv-python>=4.12.0.88",
     "pillow>=11.3.0",
     "pyautogui>=0.9.54",
     "pydantic>=2.11.7",
     "pywin32>=311; sys_platform == 'win32'",
     "mcp>=1.0.0",
     "selenium>=4.35.0",
+    "numpy>=2.2.6",
+    "opencv-python>=4.12.0.88",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -278,6 +278,7 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },
+    { name = "numpy" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pyautogui" },
@@ -302,6 +303,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "numpy", specifier = ">=2.2.6" },
     { name = "opencv-python", specifier = ">=4.12.0.88" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "pyautogui", specifier = ">=0.9.54" },


### PR DESCRIPTION
- 在 pyproject.toml 中添加 numpy>=2.2.6 依赖
- 调整 opencv-python 的顺序，移到 numpy 之后
- 更新 uv.lock 文件以反映新的依赖关系

# Pull Request

## 📝 更改说明
简要描述这个PR的主要更改

## 🎯 关联Issue
关闭 #issue_number

## 📋 更改内容
- [ ] 新增功能
- [x] Bug修复  
- [ ] 文档更新
- [ ] 代码重构
- [ ] 测试改进

## 🧪 测试情况
- [x] 本地测试通过
- [ ] 已运行 `bash scripts/test_all.sh`
- [x] 手动验证功能正常

## ⚠️ 注意事项
如有破坏性更改、新增依赖或需要特别注意的地方，请说明：

## 👀 审查要点
希望审查者重点关注的代码或设计决策：