### PR TITLE
fix(pytest): 修复MCP服务器pytest兼容性问题

### DIFF
--- a/src/mcpsectrace/mcp_servers/focus_pack_mcp.py
+++ b/src/mcpsectrace/mcp_servers/focus_pack_mcp.py
@@ -9,9 +9,10 @@ from datetime import datetime
 
 import pyautogui
 
-# --- 输出使用utf-8编码 --
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
-sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
+# --- 输出使用utf-8编码（仅在非测试环境） --
+if "pytest" not in sys.modules:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 
 # --- 全局变量 ---
 LOG_HANDLE = None

--- a/src/mcpsectrace/mcp_servers/hrkill_mcp.py
+++ b/src/mcpsectrace/mcp_servers/hrkill_mcp.py
@@ -9,9 +9,10 @@ from datetime import datetime
 
 import pyautogui
 
-# --- 输出使用utf-8编码 --
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
-sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
+# --- 输出使用utf-8编码（仅在非测试环境） --
+if "pytest" not in sys.modules:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 
 # --- 全局变量 ---
 LOG_HANDLE = None  # 日志文件句柄

--- a/src/mcpsectrace/mcp_servers/huorong_mcp.py
+++ b/src/mcpsectrace/mcp_servers/huorong_mcp.py
@@ -14,9 +14,10 @@ from typing import Optional
 import pyautogui
 from PIL import Image
 
-# --- 输出使用utf-8编码 --
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
-sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
+# --- 输出使用utf-8编码（仅在非测试环境） --
+if "pytest" not in sys.modules:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 
 # --- 导入MCP ---
 try:


### PR DESCRIPTION
# Pull Request

## 📝 更改说明
修复MCP服务器stdout重定向在pytest环境下导致的兼容性问题

## 🎯 关联Issue
关闭 #11

## 📋 更改内容
- [x] Bug修复  

## 🧪 测试情况
- [x] 本地测试通过
- [x] 已运行pytest验证修复效果
- [x] 手动验证功能正常

## ⚠️ 注意事项
仅影响测试环境行为，生产环境UTF-8编码功能保持不变

## 👀 审查要点
条件化stdout重定向逻辑是否合理